### PR TITLE
Adds support for NOT_BUILT as a selectable result

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.396</version>
+        <version>1.420</version>
     </parent>
 
     <artifactId>fail-the-build-plugin</artifactId>
@@ -42,7 +42,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    
+
     <licenses>
         <license>
             <name>The MIT license</name>
@@ -66,25 +66,25 @@
         <connection>scm:git:git://github.com/jenkinsci/fail-the-build-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/fail-the-build-plugin.git</developerConnection>
     </scm>
-    
+
     <issueManagement>
         <system>JIRA</system>
         <url>http://issues.jenkins-ci.org/</url>
     </issueManagement>
-    
+
     <distributionManagement>
         <repository>
             <id>maven.jenkins-ci.org</id>
             <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
         </repository>
     </distributionManagement>
-        
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
-                <version>1.67</version>
+                <version>1.115</version>
                 <extensions>true</extensions>
                 <configuration>
                     <compatibleSinceVersion>0.3</compatibleSinceVersion>
@@ -92,7 +92,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
 
     <repositories>
         <repository>
@@ -107,7 +107,7 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-</project>  
-  
+</project>
+
 
 

--- a/src/main/java/org/jenkins_ci/plugins/fail_the_build/FixResultBuilder.java
+++ b/src/main/java/org/jenkins_ci/plugins/fail_the_build/FixResultBuilder.java
@@ -43,14 +43,15 @@ import java.util.List;
 import java.util.Map;
 
 public class FixResultBuilder extends Builder {
-    
+
     public static final AbstractResult SUCCESS = new BallResult(Result.SUCCESS);
     public static final AbstractResult UNSTABLE = new BallResult(Result.UNSTABLE);
     public static final AbstractResult FAILURE = new BallResult(Result.FAILURE);
     public static final AbstractResult ABORTED = new BallResult(Result.ABORTED);
+    public static final AbstractResult NOT_BUILT = new BallResult(Result.NOT_BUILT);
     public static final AbstractResult CYCLE = new CycleResult();
-    
-    public static final AbstractResult[] RESULTS = {SUCCESS, UNSTABLE, FAILURE, ABORTED, CYCLE};
+
+    public static final AbstractResult[] RESULTS = {SUCCESS, UNSTABLE, FAILURE, ABORTED, NOT_BUILT, CYCLE};
 
     private transient Map<Integer, AbstractResult> resultsByBuildNumber = null;
     private final String defaultResultName;
@@ -58,15 +59,17 @@ public class FixResultBuilder extends Builder {
     private final String unstable;
     private final String failure;
     private final String aborted;
+    private final String notBuilt;
 
     @DataBoundConstructor
     public FixResultBuilder(final String defaultResultName, final String success, final String unstable, final String failure,
-                            final String aborted) {
+                            final String aborted, final String notBuilt) {
         this.defaultResultName = defaultResultName;
         this.success = success;
         this.unstable = unstable;
         this.failure = failure;
         this.aborted = aborted;
+        this.notBuilt = notBuilt;
     }
 
     public String getDefaultResultName() {
@@ -78,6 +81,10 @@ public class FixResultBuilder extends Builder {
             if (result.getName().equals(defaultResultName)) return result;
         }
         throw new RuntimeException(Messages.exception_invalidResultName(defaultResultName));
+    }
+
+    public String getNotBuilt() {
+        return notBuilt;
     }
 
     public String getAborted() {
@@ -131,6 +138,7 @@ public class FixResultBuilder extends Builder {
         parseAndStore(UNSTABLE, unstable);
         parseAndStore(FAILURE, failure);
         parseAndStore(ABORTED, aborted);
+        parseAndStore(NOT_BUILT, notBuilt);
     }
 
     private void parseAndStore(final AbstractResult result, final String buildNumberList) {
@@ -174,6 +182,10 @@ public class FixResultBuilder extends Builder {
 
         public String getAbortedTitle() {
             return ABORTED.getDisplayName();
+        }
+
+        public String getNotBuiltTitle() {
+            return NOT_BUILT.getDisplayName();
         }
 
     }

--- a/src/main/resources/org/jenkins_ci/plugins/fail_the_build/FixResultBuilder/help-notBuilt.html
+++ b/src/main/resources/org/jenkins_ci/plugins/fail_the_build/FixResultBuilder/help-notBuilt.html
@@ -1,4 +1,3 @@
-<?jelly escape-by-default='true'?>
 <!--
   ~ The MIT License
   ~
@@ -23,26 +22,6 @@
   ~ THE SOFTWARE.
   -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-
-    <f:entry title="${%defaultResult}" field="defaultResultName">
-        <f:select/>
-    </f:entry>
-    <f:advanced>
-        <f:entry title="${descriptor.successTitle}" field="success">
-            <f:textbox/>
-        </f:entry>
-        <f:entry title="${descriptor.unstableTitle}" field="unstable">
-            <f:textbox/>
-        </f:entry>
-        <f:entry title="${descriptor.failureTitle}" field="failure">
-            <f:textbox/>
-        </f:entry>
-        <f:entry title="${descriptor.abortedTitle}" field="aborted">
-            <f:textbox/>
-        </f:entry>
-        <f:entry title="${descriptor.notBuiltTitle}" field="notBuilt">
-            <f:textbox/>
-        </f:entry>
-    </f:advanced>
-</j:jelly>
+<div>
+    A list of comma or space separated build numbers for which the result should be not built
+</div>

--- a/src/test/java/org/jenkins_ci/plugins/fail_the_build/FixResultBuilderTest.java
+++ b/src/test/java/org/jenkins_ci/plugins/fail_the_build/FixResultBuilderTest.java
@@ -35,15 +35,19 @@ public class FixResultBuilderTest extends HudsonTestCase {
     }
 
     public void testUnstable() throws Exception {
-        assertDefaultResult(Result.UNSTABLE);        
+        assertDefaultResult(Result.UNSTABLE);
     }
 
     public void testFailed() throws Exception {
-        assertDefaultResult(Result.FAILURE);        
+        assertDefaultResult(Result.FAILURE);
     }
 
     public void testAborted() throws Exception {
-        assertDefaultResult(Result.ABORTED);        
+        assertDefaultResult(Result.ABORTED);
+    }
+
+    public void testNotBuilt() throws Exception {
+        assertDefaultResult(Result.NOT_BUILT);
     }
 
     public void testCycle() throws Exception {
@@ -53,28 +57,30 @@ public class FixResultBuilderTest extends HudsonTestCase {
         buildAndAssertResult(Result.UNSTABLE, project);
         buildAndAssertResult(Result.FAILURE, project);
         buildAndAssertResult(Result.ABORTED, project);
+        buildAndAssertResult(Result.NOT_BUILT, project);
         buildAndAssertResult(Result.SUCCESS, project);
         buildAndAssertResult(Result.UNSTABLE, project);
         buildAndAssertResult(Result.FAILURE, project);
         buildAndAssertResult(Result.ABORTED, project);
+        buildAndAssertResult(Result.NOT_BUILT, project);
     }
 
     public void testBuildNumberResult() throws Exception {
         final FreeStyleProject project = createFreeStyleProject();
-        project.getBuildersList().add(createFixResultBuilder(Result.FAILURE.toString(), "1", null, null, null));
+        project.getBuildersList().add(createFixResultBuilder(Result.FAILURE.toString(), " 1 ", null, null, null, null));
         buildAndAssertResult(Result.SUCCESS, project);
     }
 
     public void testBuildNumberResultWithWhiteSpace() throws Exception {
         final FreeStyleProject project = createFreeStyleProject();
-        project.getBuildersList().add(createFixResultBuilder(Result.FAILURE.toString(), " 1 ", null, null, null));
+        project.getBuildersList().add(createFixResultBuilder(Result.FAILURE.toString(), " 1 ", null, null, null, null));
         buildAndAssertResult(Result.SUCCESS, project);
     }
 
     public void testSuccessNumbers() throws Exception {
         final String successes = "1,2, 4, 6 7 ";
         final FreeStyleProject project = createFreeStyleProject();
-        project.getBuildersList().add(createFixResultBuilder(Result.FAILURE.toString(), successes, null, null, null));
+        project.getBuildersList().add(createFixResultBuilder(Result.FAILURE.toString(), successes, null, null, null, null));
         buildAndAssertResult(Result.SUCCESS, project); // 1
         buildAndAssertResult(Result.SUCCESS, project); // 2
         buildAndAssertResult(Result.FAILURE, project);
@@ -90,8 +96,9 @@ public class FixResultBuilderTest extends HudsonTestCase {
         final String unstable = "1,3,4,10";
         final String failure = "2, 7, 8";
         final String aborted = " 5 ";
+        final String notBuilt = " 11 ";
         final FreeStyleProject project = createFreeStyleProject();
-        project.getBuildersList().add(createFixResultBuilder(Result.FAILURE.toString(), successes, unstable, failure, aborted));
+        project.getBuildersList().add(createFixResultBuilder(Result.FAILURE.toString(), successes, unstable, failure, aborted, notBuilt));
         buildAndAssertResult(Result.UNSTABLE, project); // 1
         buildAndAssertResult(Result.FAILURE, project); // 2
         buildAndAssertResult(Result.UNSTABLE, project); // 3
@@ -102,6 +109,7 @@ public class FixResultBuilderTest extends HudsonTestCase {
         buildAndAssertResult(Result.FAILURE, project); // 8
         buildAndAssertResult(Result.FAILURE, project); // 9
         buildAndAssertResult(Result.UNSTABLE, project); // 10
+        buildAndAssertResult(Result.NOT_BUILT, project); // 11
     }
 
     private void assertDefaultResult(final Result result) throws Exception {
@@ -115,12 +123,15 @@ public class FixResultBuilderTest extends HudsonTestCase {
     }
 
     private FixResultBuilder createFixResultBuilder(final String defaultConfigName) {
-        return createFixResultBuilder(defaultConfigName, null, null, null, null);
+        return createFixResultBuilder(defaultConfigName, null, null, null, null, null);
     }
 
-    private FixResultBuilder createFixResultBuilder(final String defaultConfigName, final String success, final String unstable,
-                                                    final String failure, final String aborted) {
-        return new FixResultBuilder(defaultConfigName, success, unstable, failure, aborted);
+    private FixResultBuilder createFixResultBuilder(
+            final String defaultConfigName, final String success,
+            final String unstable, final String failure, final String aborted,
+            final String notBuilt) {
+        return new FixResultBuilder(defaultConfigName, success, unstable,
+                failure, aborted, notBuilt);
     }
 
 }


### PR DESCRIPTION
My team needed to be able to conditionally flag a build as "NOT_BUILT" so I added this in. Unsure if this is of interest upstream but I wanted to offer it up just in case.
- Added NOT_BUILT as a potential result option.
- Updated to version 1.115 of the maven-hpi-plugin.
- Due to hpi plugin bump, bumped parent version to 1.420.
